### PR TITLE
pass through PATH to the subprocess so we can run sfdx

### DIFF
--- a/metecho/api/sf_run_flow.py
+++ b/metecho/api/sf_run_flow.py
@@ -302,6 +302,7 @@ def run_flow(*, cci, org_config, flow_name, project_path, user):
         "GITHUB_TOKEN": gh_token,
         # needed by sfdx
         "HOME": project_path,
+        "PATH": os.environ["PATH"],
     }
     p = subprocess.Popen(
         args,


### PR DESCRIPTION
The subprocess change broke creating scratch orgs for sfdx-format projects, and I suspect this is the solution.