### PR TITLE
Don't set branch or commit when looking up available org configs

### DIFF
--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -765,8 +765,6 @@ def available_task_org_config_names(epic, *, user):
                 repo_name=repo.name,
                 repo_url=repo.html_url,
                 repo_owner=repo.owner.login,
-                repo_branch=epic.branch_name,
-                repo_commit=repo.branch(epic.branch_name).latest_sha(),
             )
             epic.available_task_org_config_names = [
                 {"key": key, **value} for key, value in config.orgs__scratch.items()


### PR DESCRIPTION
Rationale:
- These aren't needed in order to read project_config.orgs
- It's incorrect (we're fetching the default branch, which is what we want for this, but calling it something else)
- It's failing to find the branch right after the Epic was created (due to caching on github's side, perhaps)