### PR TITLE
Use the correct branch when checking out the repository before retrieving

### DIFF
--- a/metecho/api/sf_org_changes.py
+++ b/metecho/api/sf_org_changes.py
@@ -149,7 +149,7 @@ def commit_changes_to_github(
     target_directory,
     originating_user_id,
 ):
-    with local_github_checkout(user, repo_id) as project_path:
+    with local_github_checkout(user, repo_id, branch) as project_path:
         # This won't return anything in-memory, but rather it will emit
         # files which we then copy into a source checkout, and then
         # commit and push all that.


### PR DESCRIPTION
Before, we were always checking out the default branch before retrieving changes and committing. That meant that if multiple commits were retrieved on a task branch, the later ones would remove the changes from the earlier ones. The fix is to check out the current state of the task branch as the starting point.

FYI @jgerigmeyer 