### PR TITLE
Only track other users' dev and test orgs, not playground.

### DIFF
--- a/metecho/api/push.py
+++ b/metecho/api/push.py
@@ -8,6 +8,7 @@ Websocket notifications you can subscribe to:
     project.:id
         PROJECT_UPDATE
         PROJECT_UPDATE_ERROR
+        SCRATCH_ORG_PROVISIONING
 
     epic.:id
         EPIC_UPDATE

--- a/metecho/api/serializers.py
+++ b/metecho/api/serializers.py
@@ -499,7 +499,7 @@ class TaskAssigneeSerializer(serializers.Serializer):
         if "assigned_qa" in data:
             self._handle_reassign("qa", task, data, user, originating_user_id=user_id)
             task.assigned_qa = data["assigned_qa"]
-        task.save()
+        task.finalize_task_update(originating_user_id=user_id)
         return task
 
     def _handle_reassign(

--- a/test/js/store/orgs/actions.test.js
+++ b/test/js/store/orgs/actions.test.js
@@ -2,6 +2,7 @@ import fetchMock from 'fetch-mock';
 
 import * as actions from '~js/store/orgs/actions';
 import { addUrlParams } from '~js/utils/api';
+import { ORG_TYPES } from '~js/utils/constants';
 
 import { getStoreWithHistory, storeWithThunk } from './../../utils';
 
@@ -940,14 +941,32 @@ describe('orgProvisioning', () => {
 
   test('subscribes to socket and returns action', () => {
     const store = storeWithThunk(defaultState);
-    const org = { id: 'org-id' };
+    const org = {
+      id: 'org-id',
+      owner: 'user-id',
+      org_type: ORG_TYPES.PLAYGROUND,
+    };
     const action = { type: 'SCRATCH_ORG_PROVISIONING', payload: org };
     store.dispatch(actions.orgProvisioning(org));
+
     expect(store.getActions()).toEqual([action]);
     expect(window.socket.subscribe).toHaveBeenCalledWith({
       model: 'scratch_org',
       id: 'org-id',
     });
+  });
+
+  test('does not return action if user is not owner of scratch org', () => {
+    const store = storeWithThunk(defaultState);
+    const org = {
+      id: 'org-id',
+      owner: 'other-user-id',
+      org_type: ORG_TYPES.PLAYGROUND,
+    };
+    store.dispatch(actions.orgProvisioning(org));
+
+    expect(store.getActions()).toEqual([]);
+    expect(window.socket.subscribe).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&072721)

Fixes #1087.

I was able to reproduce the main issue documented in #1087, and this fixes it by ignoring websocket events for other users' non-playground orgs.

I was _not_ able to reproduce this specific piece, however:

> Refresh your browser, and you should see the create button again. This will remain on your screen for a short time before being replaced with the creation message again (even if you don't click the button to create a new scratch org).

After a page refresh, I only see the "Create Scratch Org" button; it does not disappear again after a short time. I'm not sure how that would be happening, unless a second user was triggering another org creation on the same project. Regardless, I think this PR should resolve the issue.