### PR TITLE
Support VBT-reliant flows in Metecho

### DIFF
--- a/.heroku/start_worker.sh
+++ b/.heroku/start_worker.sh
@@ -1,0 +1,7 @@
+set -e
+
+# make Chrome available to VBT
+# Copied from https://github.com/SFDO-Tooling/MetaDeploy/pull/3468
+mkdir -p /opt/google/chrome
+ln -s /app/.apt/usr/bin/google-chrome /opt/google/chrome/chrome
+python manage.py rqworker default

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: yarn django:serve:prod
-worker: python manage.py rqworker default
+worker: sh .heroku/start_metadeploy_worker.sh
 worker-short: honcho start -f Procfile_worker_short
 release: ./.heroku/release.sh

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "reselect": "^4.1.6",
     "sockette": "^2.0.6",
     "uuid-random": "^1.3.2",
+    "vlocity": "^1.15.6",
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
@@ -157,6 +158,8 @@
     "@storybook/**/glob-parent": "^5.1.2",
     "@storybook/**/trim-newlines": "^3.0.1",
     "i18next-scanner-webpack/**/glob-parent": "^5.1.2",
+    "//": "Related to  https://github.com/isaacs/minipass/pull/41 ",
+    "minipass": "^3.3.5",
     "trim": "^0.0.3",
     "unset-value": "^2.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,6 +2972,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/minipass@*":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-3.3.5.tgz#ba65aaae3fe7318520bd4a40bc71c53fc8826e45"
+  integrity sha512-M2BLHQdEmDmH671h0GIlOQQJrgezd1vNqq7PVj1VOsHZ2uQQb4iPiQIl0SlMdhxZPUsLIfEklmeEHXg8DJRewA==
+  dependencies:
+    minipass "*"
+
 "@types/ms@*":
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
@@ -14974,6 +14981,38 @@ vinyl@^2.0.0, vinyl@^2.2.0:
     cloneable-readable "^1.0.0"
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
+
+vlocity@^1.15.6:
+  version "1.15.8"
+  resolved "https://registry.yarnpkg.com/vlocity/-/vlocity-1.15.8.tgz#cf0178bea3e6e689dea8d190d385714be2f7017e"
+  integrity sha512-v8p7v9vpNbgV3H0KzeqEgvGqDRYO5AcmvdXoMHYUjvL3bIC6mVB3ZqzOrhmpp5TjHKoBPfX1Oi+zEDYLTEzgjw==
+  dependencies:
+    async "3.2.0"
+    diff2html "2.5.0"
+    fast-json-stable-stringify "2.1.0"
+    file-type "10.9.0"
+    filterxml "1.1.4"
+    fs-extra "8.0.1"
+    git-diff "2.0.6"
+    global-modules-path "^2.3.1"
+    ignore "5.0.4"
+    is-utf8 "0.2.1"
+    js-yaml "3.13.1"
+    jsforce "1.9.3"
+    json-stable-stringify "1.0.1"
+    mustache "3.0.0"
+    nopt "4.0.1"
+    opn "6.0.0"
+    properties "1.2.1"
+    puppeteer-core "^5.3.1"
+    runtime-plugin-manager-clone "0.1.0"
+    salesforce-alm "49.5.0"
+    sass.js "0.11.1"
+    semver "6.2.0"
+    simple-git "1.107.0"
+    unidecode "0.1.8"
+    xml2js "0.4.22"
+    xmlbuilder "13.0.2"
 
 vm-browserify@^1.0.1:
   version "1.1.2"


### PR DESCRIPTION
Metecho equivalent of: https://github.com/SFDO-Tooling/MetaDeploy/pull/3468

Make a [new script](https://github.com/SFDO-Tooling/Metecho/blob/363a17e96672a34ffa48681592c3c561fa498098/.heroku/start_worker.sh) that makes Chrome available to the VBT compiler.

Invoke it from [Procfile](https://github.com/SFDO-Tooling/Metecho/blob/363a17e96672a34ffa48681592c3c561fa498098/Procfile).

Install Vlocity and Upgrade "[MiniPass](https://github.com/SFDO-Tooling/Metecho/compare/feature/support-vbt?expand=1#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de)" to work around a bug that seems to have arisen asynchronously (perhaps the type declarations are downloaded at runtime).