### PR TITLE
Default `GitHubCollaboration` Permissions

### DIFF
--- a/metecho/api/migrations/0113_github_models_populate.py
+++ b/metecho/api/migrations/0113_github_models_populate.py
@@ -22,14 +22,8 @@ def forwards(apps, schema_editor):
                 },
             )
 
-            # receiving KeyError on "permissions"
-            # for some users in the wild
-            perms = None
-            if "permissions" in collaborator:
-                perms = collaborator["permissions"]
-
             GitHubCollaboration.objects.create(
-                project=project, user=user, permissions=perms
+                project=project, user=user, permissions=collaborator.get("permissions")
             )
 
     # Convert JSON Epic collaborators into m2m entries

--- a/metecho/api/migrations/0113_github_models_populate.py
+++ b/metecho/api/migrations/0113_github_models_populate.py
@@ -21,8 +21,15 @@ def forwards(apps, schema_editor):
                     "avatar_url": collaborator.get("avatar_url", ""),
                 },
             )
+
+            # receiving KeyError on "permissions"
+            # for some users in the wild
+            perms = None
+            if "permissions" in collaborator:
+                perms = collaborator["permissions"]
+
             GitHubCollaboration.objects.create(
-                project=project, user=user, permissions=collaborator["permissions"]
+                project=project, user=user, permissions=perms
             )
 
     # Convert JSON Epic collaborators into m2m entries


### PR DESCRIPTION
The migration now defaults the permissions on a GitHubCollaboration to `None` if they are not present on a user.