### PR TITLE
Fix calls to `local_github_checkout`.

### DIFF
--- a/metecho/api/gh.py
+++ b/metecho/api/gh.py
@@ -205,7 +205,11 @@ def extract_zip_file(zip_file, owner, repo_name):
 
 @contextlib.contextmanager
 def local_github_checkout(
-    user=None, repo_id=None, commit_ish=None, repo_owner=None, repo_name=None,
+    user=None,
+    repo_id=None,
+    commit_ish=None,
+    repo_owner=None,
+    repo_name=None,
 ):
     with temporary_dir() as repo_root:
         # pretend it's a git clone to satisfy cci

--- a/metecho/api/gh.py
+++ b/metecho/api/gh.py
@@ -205,7 +205,7 @@ def extract_zip_file(zip_file, owner, repo_name):
 
 @contextlib.contextmanager
 def local_github_checkout(
-    user=None, repo_id=None, repo_owner=None, repo_name=None, commit_ish=None
+    user=None, repo_id=None, commit_ish=None, repo_owner=None, repo_name=None,
 ):
     with temporary_dir() as repo_root:
         # pretend it's a git clone to satisfy cci
@@ -214,8 +214,10 @@ def local_github_checkout(
         repo = get_repo_info(
             user=user, repo_id=repo_id, repo_owner=repo_owner, repo_name=repo_name
         )
-        if commit_ish is None:
+        if commit_ish == "#DEFAULT":
             commit_ish = repo.default_branch
+        assert commit_ish, "Default branch should be supplied"
+
         zip_file = get_zip_file(repo, commit_ish)
 
         if not zip_file_is_safe(zip_file):

--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -520,9 +520,7 @@ def refresh_scratch_org(scratch_org, *, originating_user_id):
 
         delete_org(scratch_org)
 
-        with local_github_checkout(
-            user, repo_id, commit_ish
-        ) as repo_root:
+        with local_github_checkout(user, repo_id, commit_ish) as repo_root:
             _create_org_and_run_flow(
                 scratch_org,
                 user=user,

--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -87,7 +87,7 @@ def creating_gh_branch(instance):
 def get_branch_prefix(user, repository: Repository):
     if settings.BRANCH_PREFIX:
         return settings.BRANCH_PREFIX
-    with local_github_checkout(user, repository.id) as repo_root:
+    with local_github_checkout(user, repository.id, "#DEFAULT") as repo_root:
         return get_cumulus_prefix(
             repo_root=repo_root,
             repo_name=repository.name,
@@ -520,7 +520,9 @@ def refresh_scratch_org(scratch_org, *, originating_user_id):
 
         delete_org(scratch_org)
 
-        with local_github_checkout(user, repo_id, commit_ish) as repo_root:
+        with local_github_checkout(
+            user, repo_id, commit_ish
+        ) as repo_root:
             _create_org_and_run_flow(
                 scratch_org,
                 user=user,
@@ -1102,7 +1104,7 @@ def available_org_config_names(project, *, user):
             repo_owner=project.repo_owner,
             repo_name=project.repo_name,
         )
-        with local_github_checkout(user, repo_id) as repo_root:
+        with local_github_checkout(user, repo_id, "#DEFAULT") as repo_root:
             config = get_project_config(
                 repo_root=repo_root,
                 repo_name=repo.name,

--- a/metecho/api/tests/gh.py
+++ b/metecho/api/tests/gh.py
@@ -190,7 +190,7 @@ class TestLocalGitHubCheckout:
             glob.return_value = [".."]
 
             with pytest.raises(UnsafeZipfileError):
-                with local_github_checkout( user, repo, "commit-ish" ):  # pragma: nocover
+                with local_github_checkout(user, repo, "commit-ish"):  # pragma: nocover
                     pass
 
     def test_cumulusci_yml_error(self, mocker):

--- a/metecho/api/tests/gh.py
+++ b/metecho/api/tests/gh.py
@@ -168,7 +168,7 @@ class TestLocalGitHubCheckout:
             gh_as_user.return_value = gh
             glob.return_value = ["owner-repo_name-"]
 
-            with local_github_checkout(user, repo) as repo_root:
+            with local_github_checkout(user, repo, "main") as repo_root:
                 assert (Path(repo_root) / "cumulusci.yml").read_text() == "Hello"
                 assert shutil.rmtree.called
                 assert os.remove.called
@@ -190,7 +190,7 @@ class TestLocalGitHubCheckout:
             glob.return_value = [".."]
 
             with pytest.raises(UnsafeZipfileError):
-                with local_github_checkout(user, repo, "commit-ish"):  # pragma: nocover
+                with local_github_checkout( user, repo, "commit-ish" ):  # pragma: nocover
                     pass
 
     def test_cumulusci_yml_error(self, mocker):
@@ -209,7 +209,7 @@ class TestLocalGitHubCheckout:
         glob.return_value = ["owner-repo_name-"]
 
         with pytest.raises(Exception):
-            with local_github_checkout(user, repo_id):
+            with local_github_checkout(user, repo_id, "#DEFAULT"):
                 pass  # pragma: nocover
 
 


### PR DESCRIPTION
Many calls to `local_github_checkout` assumed that the third argument was commit_ish. It wasn't, anymore. So these calls were ending up with `main` as a fallback.

Two changes:

 1. It's the third argument again. (so the broken calls are fixed now)

 2. Now it is essentially mandatory (through an assertion, not the arglist)
 
 I did an audit of every use-case to make sure that nowhere was it using the third argument positionally EXCEPT as `commit_ish`.