### PR TITLE
Prevent 403 when copying branch protection rules

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -346,7 +346,7 @@
   "Submitting a review…": "Submitting a review…",
   "Submitting changes for testing…": "Submitting changes for testing…",
   "Submitting review…": "Submitting review…",
-  "Successfully created GitHub Repository for new Project: “{{project_name}}.”": "Successfully created GitHub Repository for new Project: “{{project_name}}.”",
+  "Successfully created GitHub Repository for new Project: “{{project_name}}.” Please ensure to enable branch protection rules on your main branch.": "Successfully created GitHub Repository for new Project: “{{project_name}}.” Please ensure to enable branch protection rules on your main branch.",
   "Successfully created {{orgType}} for {{parent}} “{{name}}.”": "Successfully created {{orgType}} for {{parent}} “{{name}}.”",
   "Successfully created {{orgType}}.": "Successfully created {{orgType}}.",
   "Successfully deleted {{orgType}} for {{parent}} “{{name}}.”": "Successfully deleted {{orgType}} for {{parent}} “{{name}}.”",

--- a/locales_dev/en/translation.json
+++ b/locales_dev/en/translation.json
@@ -345,7 +345,7 @@
   "Submitting a review…": "Submitting a review…",
   "Submitting changes for testing…": "Submitting changes for testing…",
   "Submitting review…": "Submitting review…",
-  "Successfully created GitHub Repository for new Project: “{{project_name}}.”": "Successfully created GitHub Repository for new Project: “{{project_name}}.”",
+  "Successfully created GitHub Repository for new Project: “{{project_name}}.” Please ensure to enable branch protection rules on your main branch.": "Successfully created GitHub Repository for new Project: “{{project_name}}.” Please ensure to enable branch protection rules on your main branch.",
   "Successfully created {{orgType}} for {{parent}} “{{name}}.”": "Successfully created {{orgType}} for {{parent}} “{{name}}.”",
   "Successfully created {{orgType}}.": "Successfully created {{orgType}}.",
   "Successfully deleted {{orgType}} for {{parent}} “{{name}}.”": "Successfully deleted {{orgType}} for {{parent}} “{{name}}.”",

--- a/metecho/api/gh.py
+++ b/metecho/api/gh.py
@@ -38,7 +38,8 @@ class NoGitHubTokenError(Exception):
     pass
 
 
-def copy_branch_protection(source: Branch, target: Branch):
+# This currently is _not_ being used, so we don't want to include it for coverage
+def copy_branch_protection(source: Branch, target: Branch):  # pragma: nocover
     """
     Copy the branch protection [output][1] of one branch into the [input][2] of another.
 
@@ -50,8 +51,16 @@ def copy_branch_protection(source: Branch, target: Branch):
 
     [1]: https://docs.github.com/en/rest/branches/branch-protection#get-branch-protection
     [2]: https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
+
     """
-    protection = source.protection().as_dict()
+    try:
+        # source.protection() currently throws a 403 stating that app permissions are not
+        # correct. As far as we can tell, this is a bug with GitHub App permissioning.
+        protection = source.protection().as_dict()
+    except NotFoundError:
+        # 404 is returned if no branch protection rules are enabled
+        return
+
     reviews = protection["required_pull_request_reviews"]
 
     required_pull_request_reviews = {

--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -38,7 +38,6 @@ from github3.repos.repo import Repository
 
 from .email_utils import get_user_facing_url
 from .gh import (
-    copy_branch_protection,
     get_all_org_repos,
     get_cached_user,
     get_cumulus_prefix,
@@ -280,10 +279,11 @@ def create_repository(
                 raise Exception("Failed to push files to GitHub repository")
 
         # Copy branch protection rules from the template repo
-        if tpl_repo:
-            copy_branch_protection(
-                source=tpl_repo.branch(branch_name), target=repo.branch(branch_name)
-            )
+        # See copy_branch_protection() for why we don't use this currently
+        # if tpl_repo:
+        #     copy_branch_protection(
+        #         source=tpl_repo.branch(branch_name), target=repo.branch(branch_name)
+        #     )
     except Exception as e:
         project.finalize_create_repository(error=e, user=user)
         tb = traceback.format_exc()
@@ -875,9 +875,9 @@ def refresh_github_users(project: Project, *, originating_user_id):
         for collaborator in repo.collaborators():
             try:
                 # Retrieve additional information for each user by querying GitHub
-                collaborator.name = get_cached_user(
-                    GitHub(repo), collaborator.login
-                ).name
+                collaborator.name = (
+                    get_cached_user(GitHub(repo), collaborator.login).name or ""
+                )
             except Exception:
                 logger.exception(f"Failed to expand GitHub user {collaborator}")
                 collaborator.name = ""

--- a/metecho/api/tests/gh.py
+++ b/metecho/api/tests/gh.py
@@ -9,6 +9,7 @@ from github3.exceptions import NotFoundError, UnprocessableEntity
 from ..gh import (
     NoGitHubTokenError,
     UnsafeZipfileError,
+    copy_branch_protection,
     extract_zip_file,
     get_all_org_repos,
     get_cached_user,
@@ -82,6 +83,14 @@ def test_log_unsafe_zipfile_error():
     with patch(f"{PATCH_ROOT}.logger") as logger:
         log_unsafe_zipfile_error("repo_url", "commit_ish")
         assert logger.error.called
+
+
+def test_copy_branch_protection_rules__not_enabled():
+    target_branch = MagicMock()
+    source_branch = MagicMock()
+    source_branch.protection.side_effect = NotFoundError(MagicMock())
+    result = copy_branch_protection(source_branch, target_branch)
+    assert result is None
 
 
 @pytest.mark.django_db

--- a/src/js/store/projects/actions.ts
+++ b/src/js/store/projects/actions.ts
@@ -178,7 +178,7 @@ export const projectCreated =
       dispatch(
         addToast({
           heading: t(
-            'Successfully created GitHub Repository for new Project: “{{project_name}}.”',
+            'Successfully created GitHub Repository for new Project: “{{project_name}}.” Please ensure to enable branch protection rules on your main branch.',
             { project_name: model.name },
           ),
           linkText: model.repo_url


### PR DESCRIPTION
This PR covers two separate bugs:

1. When branch protection rules _are not_ enabled on a branch, GitHub will return a 404. This exception was not being properly caught and handled, but now is.
2. When branch protection rules _are_ enabled we are running into an error where the GitHub API is returning a 403. This error is outlined in more detail in W-12000044.

We also now prompt the user to enable branch protection rules are a repository is successfully created:
![Screen Shot 2022-11-03 at 10 58 06 AM](https://user-images.githubusercontent.com/6100538/199801771-8b5b3a6b-d407-4ec2-b47b-6f6bc3059377.png)

