### PR TITLE
Override toast focus to pre-determined div

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,30 +1,55 @@
-{% load api_bootstrap %}
-{% load js_reverse %}
-{% load static %}
+{% load api_bootstrap %} {% load js_reverse %} {% load static %}
 
 <!DOCTYPE html>
 <html lang="en" dir="ltr" class="slds-theme_default">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
-    {% block robots %}<meta name="robots" content="index, follow" />{% endblock %}
+    {% block robots %}
+    <meta name="robots" content="index, follow" />
+    {% endblock %}
     <meta name="author" content="Salesforce.org" />
-    <meta name="keywords" content="{% block keywords %}{% endblock keywords %}" />
+    <meta
+      name="keywords"
+      content="{% block keywords %}{% endblock keywords %}"
+    />
     <meta name="language" content="en-us" />
-    <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="{% static 'images/apple-touch-icon.png' %}">
-    <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/favicon-32x32.png' %}">
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/favicon-16x16.png' %}">
-    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.ico' %}" />
+    <link
+      rel="apple-touch-icon"
+      type="image/png"
+      sizes="180x180"
+      href="{% static 'images/apple-touch-icon.png' %}"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="{% static 'images/favicon-32x32.png' %}"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="{% static 'images/favicon-16x16.png' %}"
+    />
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="{% static 'images/favicon.ico' %}"
+    />
 
     <!-- Page Info -->
     <title>{% block title %}Metecho{% endblock %}</title>
-    <meta name="description" content="{% block description %}Web-based tool for collaborating on Salesforce projects{% endblock description %}" />
+    <meta
+      name="description"
+      content="{% block description %}Web-based tool for collaborating on Salesforce projects{% endblock description %}"
+    />
 
     {% if GLOBALS.SENTRY_DSN %}
-      <!-- Insert Sentry setup -->
-      <script id="js-sentry-setup" type="application/json">
-        { "dsn": "{{ GLOBALS.SENTRY_DSN }}" }
-      </script>
+    <!-- Insert Sentry setup -->
+    <script id="js-sentry-setup" type="application/json">
+      { "dsn": "{{ GLOBALS.SENTRY_DSN }}" }
+    </script>
     {% endif %}
     <!-- Insert config variables from Django -->
     {{ GLOBALS|json_script:"js-globals" }}
@@ -36,12 +61,23 @@
     <!-- JavaScript and Styles are inserted here -->
   </head>
   <body>
-    <main id="app" class="slds-grid slds-grid_vertical"{% if user.is_authenticated %} data-user="{{ user|serialize }}"{% endif %}>
+    <div
+      id="app"
+      class="slds-grid slds-grid_vertical"
+      {%
+      if
+      user.is_authenticated
+      %}
+      data-user="{{ user|serialize }}"
+      {%
+      endif
+      %}
+    >
       <div role="status" class="slds-spinner slds-spinner_large">
         <span class="slds-assistive-text">Loading…</span>
         <div class="slds-spinner__dot-a"></div>
         <div class="slds-spinner__dot-b"></div>
       </div>
-    </main>
+    </div>
   </body>
 </html>

--- a/src/js/components/projects/list.tsx
+++ b/src/js/components/projects/list.tsx
@@ -240,7 +240,10 @@ const ProjectList = (
         </div>
 
         <div className="slds-p-around_x-large">
-          <div className="slds-grid slds-wrap slds-grid_pull-padded-small">
+          <div
+            tabIndex={-1}
+            className="metecho-toast-focus slds-grid slds-wrap slds-grid_pull-padded-small"
+          >
             <div
               className="slds-p-horizontal_small
                 slds-m-bottom_medium

--- a/src/js/components/projects/list.tsx
+++ b/src/js/components/projects/list.tsx
@@ -240,7 +240,7 @@ const ProjectList = (
         </div>
 
         <div className="slds-p-around_x-large">
-          <div
+          <main
             tabIndex={-1}
             className="metecho-toast-focus slds-grid slds-wrap slds-grid_pull-padded-small"
           >
@@ -280,7 +280,7 @@ const ProjectList = (
                 </Trans>
               </ul>
             </div>
-          </div>
+          </main>
           {refreshing ? (
             <div className="slds-align_absolute-center slds-m-top_x-large">
               <span className="slds-is-relative">

--- a/src/js/components/toasts.tsx
+++ b/src/js/components/toasts.tsx
@@ -14,6 +14,14 @@ const ToastMessage = withRouter(
     const closeToast = useCallback(() => {
       if (toast.id) {
         dispatch(removeToast(toast.id));
+
+        // Override default toast close behavior because default behavior
+        // selects HTML body when toast can't find openeing element,
+        // which is basically always in our case.
+        const wrapper = document.getElementsByClassName('metecho-toast-focus');
+        if (wrapper.length) {
+          (wrapper[0] as HTMLElement).focus();
+        }
       }
     }, [dispatch, toast]);
     const linkClicked = () => {

--- a/src/js/components/utils/detailPageLayout.tsx
+++ b/src/js/components/utils/detailPageLayout.tsx
@@ -147,12 +147,15 @@ const DetailPageLayout = ({
         </div>
       </div>
       <div
-        className="slds-p-around_x-large
+        // tabIndex required for toast close focus
+        tabIndex={-1}
+        className="metecho-toast-focus
+          slds-p-around_x-large
           slds-grid
           slds-gutters
           slds-wrap"
       >
-        <div
+        <aside
           className="slds-col
             slds-size_1-of-1
             slds-medium-size_4-of-12
@@ -167,8 +170,8 @@ const DetailPageLayout = ({
             />
           )}
           {sidebar}
-        </div>
-        <div
+        </aside>
+        <main
           className="slds-col
             slds-size_1-of-1
             slds-medium-size_8-of-12
@@ -176,7 +179,7 @@ const DetailPageLayout = ({
             slds-p-bottom_x-large"
         >
           {children}
-        </div>
+        </main>
       </div>
     </>
   );

--- a/test/js/components/toasts.test.jsx
+++ b/test/js/components/toasts.test.jsx
@@ -80,5 +80,26 @@ describe('<Toasts />', () => {
 
       expect(removeToast).not.toHaveBeenCalled();
     });
+
+    test('removeToast focus control', () => {
+      const { getByText } = setup();
+
+      /* Setup dom nodes for test */
+      const divNode = document.createElement('div');
+      divNode.classList.add('metecho-toast-focus');
+
+      const mockGetElement = jest.spyOn(document, 'getElementsByClassName');
+      const mockFocus = jest.spyOn(divNode, 'focus');
+      mockGetElement.mockReturnValue([divNode]);
+      Object.defineProperty(document, 'getElementsByClassName', {
+        value: mockGetElement,
+      });
+
+      fireEvent.click(getByText('Close'));
+
+      expect(mockGetElement).toHaveBeenCalled();
+      expect(mockFocus).toHaveBeenCalled();
+      // expect(divNode).toHaveFocus();
+    });
   });
 });


### PR DESCRIPTION
Almost all the toasts in Metecho are generated from some type of async process, like an error, or the creation of a scratch org etc. This means the element that creates the toast is almost never available, so the focus is sent to the `<body>` of the HTML. This could be confusing or inconvenient for users, so we instead move focus for the main div wrapping the meaningingful content of the page.

Control of focus aft4er a toast is closed is be controlled by the `<toasts>` component. Any main layout component that needs to take advantage of the focus adds `metecho-toast-focus` as a css class to a wrapping `<div>` with `tabIndex={-1}` which allows the div to become focusable.

Also I updated the markup of `<DetailPageLayout>` to include `<main>` and `<aside>` which are more appropriate semantic elements.