### PR TITLE
Get the saleforce client from the project/org pair, to use the right API version

### DIFF
--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -24,6 +24,7 @@ from cumulusci.core.datasets import (
 )
 from cumulusci.core.runtime import BaseCumulusCI
 from cumulusci.salesforce_api.org_schema import Field, Filters, Schema, get_org_schema
+from cumulusci.salesforce_api.utils import get_simple_salesforce_connection
 from cumulusci.tasks.github.util import CommitDir
 from cumulusci.tasks.vlocity.vlocity import VlocityRetrieveTask
 from cumulusci.utils import download_extract_github, temporary_dir
@@ -1255,7 +1256,7 @@ def dataset_env(org: ScratchOrg):
         )
         org_config = org.get_refreshed_org_config(keychain=cci.keychain)
         project_config.keychain = org_config.keychain
-        sf = org_config.salesforce_client
+        sf = get_simple_salesforce_connection(project_config, org_config)
         with get_org_schema(
             sf,
             org_config,

--- a/metecho/api/tests/jobs.py
+++ b/metecho/api/tests/jobs.py
@@ -1624,8 +1624,9 @@ class FakeSchema:
 def patch_dataset_env(mocker, tmp_path):
     """Mock all values returned by SF and GH APIs in the `dataset_env` context manager"""
     repo = mocker.MagicMock()
+    instance_url = "https://chocolate-cappuccino-8174-dev-ed.scratch.my.salesforce.com"
     project_config = mocker.MagicMock(repo_root=str(tmp_path))
-    org_config = mocker.MagicMock()
+    org_config = mocker.MagicMock(instance_url=instance_url)
     sf = mocker.MagicMock()
     schema = FakeSchema()
 


### PR DESCRIPTION
Previously, we used this method to get the salesforce client to decide what field are available to pull:

`org_config.get_salesforce_client`

This returns the latest API for the org. It's kind of a dangerous method which should only be used when the other one isn't possible (i.e. there is no project available).

The new code uses the better method and respects the project's requested API version.
