### PR TITLE
Remove epic progress rings due to accessibility bug

### DIFF
--- a/src/js/components/epics/table/statusCell.tsx
+++ b/src/js/components/epics/table/statusCell.tsx
@@ -11,7 +11,7 @@ const StatusTableCell = ({ item, className, ...props }: TableCellProps) => {
     return null;
   }
 
-  const { status, icon } = getEpicStatus({
+  const { status } = getEpicStatus({
     epicStatus: item.status,
   });
 
@@ -21,7 +21,6 @@ const StatusTableCell = ({ item, className, ...props }: TableCellProps) => {
       title={status}
       className={classNames(className, 'status-cell', 'complex-cell')}
     >
-      {icon}
       <span className="slds-m-left_x-small status-cell-text">{status}</span>
     </DataTableCell>
   );

--- a/src/js/components/githubIssues/selectIssueModal.tsx
+++ b/src/js/components/githubIssues/selectIssueModal.tsx
@@ -84,14 +84,11 @@ const TaskStatus = ({ task }: { task: IssueTask }) => {
 };
 
 const EpicStatus = ({ epic }: { epic: IssueEpic }) => {
-  const { status, icon } = getEpicStatus({ epicStatus: epic.status });
+  const { status } = getEpicStatus({ epicStatus: epic.status });
 
   return (
-    <span
-      className="slds-m-left_x-small v-align-center icon-text-block"
-      title={status}
-    >
-      {icon}
+    <span className="slds-m-left_x-small v-align-center icon-text-block">
+      {status}
     </span>
   );
 };

--- a/src/js/components/githubIssues/selectIssueModal.tsx
+++ b/src/js/components/githubIssues/selectIssueModal.tsx
@@ -3,6 +3,7 @@ import Icon from '@salesforce/design-system-react/components/icon';
 import Modal from '@salesforce/design-system-react/components/modal';
 import Radio from '@salesforce/design-system-react/components/radio';
 import RadioGroup from '@salesforce/design-system-react/components/radio-group';
+import { t } from 'i18next';
 import React, { ChangeEvent, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
@@ -85,10 +86,9 @@ const TaskStatus = ({ task }: { task: IssueTask }) => {
 
 const EpicStatus = ({ epic }: { epic: IssueEpic }) => {
   const { status } = getEpicStatus({ epicStatus: epic.status });
-
   return (
     <span className="slds-m-left_x-small v-align-center icon-text-block">
-      {status}
+      {`${t('Status')}: ${status}`}
     </span>
   );
 };

--- a/src/js/components/githubIssues/selectIssueModal.tsx
+++ b/src/js/components/githubIssues/selectIssueModal.tsx
@@ -3,7 +3,6 @@ import Icon from '@salesforce/design-system-react/components/icon';
 import Modal from '@salesforce/design-system-react/components/modal';
 import Radio from '@salesforce/design-system-react/components/radio';
 import RadioGroup from '@salesforce/design-system-react/components/radio-group';
-import { t } from 'i18next';
 import React, { ChangeEvent, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/src/js/components/githubIssues/selectIssueModal.tsx
+++ b/src/js/components/githubIssues/selectIssueModal.tsx
@@ -84,6 +84,7 @@ const TaskStatus = ({ task }: { task: IssueTask }) => {
 };
 
 const EpicStatus = ({ epic }: { epic: IssueEpic }) => {
+  const { t } = useTranslation();
   const { status } = getEpicStatus({ epicStatus: epic.status });
   return (
     <span className="slds-m-left_x-small v-align-center icon-text-block">

--- a/src/js/components/utils/getEpicStatus.tsx
+++ b/src/js/components/utils/getEpicStatus.tsx
@@ -1,33 +1,26 @@
-import ProgressRing from '@salesforce/design-system-react/components/progress-ring';
 import { t } from 'i18next';
-import React from 'react';
 
 import { EPIC_STATUSES, EpicStatuses } from '@/js/utils/constants';
 
 const getEpicStatus = ({ epicStatus }: { epicStatus: EpicStatuses }) => {
-  let displayStatus, icon;
+  let displayStatus;
   switch (epicStatus) {
     case EPIC_STATUSES.PLANNED:
       displayStatus = t('Planned');
-      icon = <ProgressRing value={0} />;
       break;
     case EPIC_STATUSES.IN_PROGRESS:
       displayStatus = t('In Progress');
-      icon = <ProgressRing value={40} flowDirection="fill" theme="active" />;
       break;
     case EPIC_STATUSES.REVIEW:
       displayStatus = t('Review');
-      icon = <ProgressRing value={100} />;
       break;
     case EPIC_STATUSES.MERGED:
       displayStatus = t('Merged');
-      icon = <ProgressRing value={100} theme="complete" hasIcon />;
       break;
   }
 
   return {
     status: displayStatus || epicStatus,
-    icon,
   };
 };
 


### PR DESCRIPTION
remove epic table progress rings slds react component due to lack of aria-label in standard compnent. Since the progress indicator is visual only  the removal has a limited impact.