### PR TITLE
increase margin to allow focus indicator to show

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -17,3 +17,7 @@
   border-radius: 0;
   box-shadow: none;
 }
+
+.walkthrough-metecho-name {
+  margin: 3px;
+}


### PR DESCRIPTION
Before:
![4 1-16](https://github.com/SFDO-Tooling/Metecho/assets/4258978/71aef37a-3c48-4b04-998e-107cd6761bbe)

after: 
<img width="587" alt="Screenshot 2023-05-25 at 4 34 45 PM" src="https://github.com/SFDO-Tooling/Metecho/assets/4258978/10837ef1-0812-4a8a-9981-851e357651a4">
