### PR TITLE
remove h2 due to incorect heading order

### DIFF
--- a/src/js/components/orgs/taskOrgCards.tsx
+++ b/src/js/components/orgs/taskOrgCards.tsx
@@ -283,9 +283,9 @@ const TaskOrgCards = ({
 
   return (
     <>
-      <h2 className="slds-text-heading_medium slds-m-bottom_xx-small">
+      <div className="slds-text-heading_medium slds-m-bottom_xx-small">
         {t('Task Team & Orgs')}
-      </h2>
+      </div>
       <div className="slds-grid slds-wrap slds-grid_pull-padded-x-small">
         <TaskOrgCard
           org={orgs[ORG_TYPES.DEV]}


### PR DESCRIPTION
There were too many H2 elements, but I could not remove the H@ elements used in the card headings because they are hardcoded to H2s in the card component. So I removed the H2 element since the H2 element was redundant to the titles of the sections afterward. 