### PR TITLE
Focus order fixed for retrieve metadata modal 

### DIFF
--- a/src/js/components/tasks/retrieveMetadata/changes.tsx
+++ b/src/js/components/tasks/retrieveMetadata/changes.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@salesforce/design-system-react/components/checkbox';
 import Icon from '@salesforce/design-system-react/components/icon';
 import Tooltip from '@salesforce/design-system-react/components/tooltip';
 import classNames from 'classnames';
-import React, { ChangeEvent, useState, useRef, useEffect } from 'react';
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {

--- a/src/js/components/tasks/retrieveMetadata/changes.tsx
+++ b/src/js/components/tasks/retrieveMetadata/changes.tsx
@@ -4,7 +4,7 @@ import Checkbox from '@salesforce/design-system-react/components/checkbox';
 import Icon from '@salesforce/design-system-react/components/icon';
 import Tooltip from '@salesforce/design-system-react/components/tooltip';
 import classNames from 'classnames';
-import React, { ChangeEvent, useState } from 'react';
+import React, { ChangeEvent, useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -207,6 +207,12 @@ const ChangesForm = ({
   ) => {
     updateChecked(ignoredChanges, checked);
   };
+  const checkboxRef = useRef(null);
+  useEffect(() => {
+    if (checkboxRef.current && checkboxRef.current?.input) {
+      checkboxRef.current.input.focus();
+    }
+  }, [totalChanges]);
 
   return (
     <form
@@ -239,6 +245,7 @@ const ChangesForm = ({
                 indeterminate={Boolean(!allChangesChecked && !noChangesChecked)}
                 errorText={errors.changes}
                 onChange={handleSelectAllChange}
+                ref={checkboxRef}
               />
               <span className="slds-text-body_regular slds-p-top_xxx-small">
                 ({totalChanges})

--- a/src/js/components/tasks/retrieveMetadata/changes.tsx
+++ b/src/js/components/tasks/retrieveMetadata/changes.tsx
@@ -4,13 +4,7 @@ import Checkbox from '@salesforce/design-system-react/components/checkbox';
 import Icon from '@salesforce/design-system-react/components/icon';
 import Tooltip from '@salesforce/design-system-react/components/tooltip';
 import classNames from 'classnames';
-import React, {
-  ChangeEvent,
-  RefObject,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ChangeEvent, RefObject, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {

--- a/src/js/components/tasks/retrieveMetadata/changes.tsx
+++ b/src/js/components/tasks/retrieveMetadata/changes.tsx
@@ -209,8 +209,10 @@ const ChangesForm = ({
   };
   const checkboxRef = useRef(null);
   useEffect(() => {
-    if (checkboxRef.current && checkboxRef.current?.input) {
-      checkboxRef.current.input.focus();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (checkboxRef.current && checkboxRef.current!.input) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      checkboxRef.current!.input.focus();
     }
   }, [totalChanges]);
 

--- a/src/js/components/tasks/retrieveMetadata/changes.tsx
+++ b/src/js/components/tasks/retrieveMetadata/changes.tsx
@@ -4,7 +4,13 @@ import Checkbox from '@salesforce/design-system-react/components/checkbox';
 import Icon from '@salesforce/design-system-react/components/icon';
 import Tooltip from '@salesforce/design-system-react/components/tooltip';
 import classNames from 'classnames';
-import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import React, {
+  ChangeEvent,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -207,14 +213,25 @@ const ChangesForm = ({
   ) => {
     updateChecked(ignoredChanges, checked);
   };
-  const checkboxRef = useRef(null);
+
+  interface CheckboxRefType {
+    input?: HTMLElement | null;
+    // Add other properties if needed
+  }
+  // eslint-disable-next-line import/no-named-as-default-member
+  const checkboxRef: RefObject<CheckboxRefType> = React.createRef();
+  // const checkboxRef = useRef(null);
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    if (checkboxRef.current && checkboxRef.current!.input) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      checkboxRef.current!.input.focus();
+    const currentRef = checkboxRef.current;
+
+    if (
+      currentRef &&
+      currentRef.input &&
+      typeof currentRef.input.focus === 'function'
+    ) {
+      currentRef.input.focus();
     }
-  }, [totalChanges]);
+  }, [checkboxRef, totalChanges]);
 
   return (
     <form

--- a/src/js/components/tasks/retrieveMetadata/changes.tsx
+++ b/src/js/components/tasks/retrieveMetadata/changes.tsx
@@ -210,14 +210,10 @@ const ChangesForm = ({
 
   interface CheckboxRefType {
     input?: HTMLElement | null;
-    // Add other properties if needed
   }
-  // eslint-disable-next-line import/no-named-as-default-member
   const checkboxRef: RefObject<CheckboxRefType> = React.createRef();
-  // const checkboxRef = useRef(null);
   useEffect(() => {
     const currentRef = checkboxRef.current;
-
     if (
       currentRef &&
       currentRef.input &&

--- a/test/js/components/tasks/retrieveMetadata/index.test.jsx
+++ b/test/js/components/tasks/retrieveMetadata/index.test.jsx
@@ -115,6 +115,7 @@ describe('<RetrieveMetadataModal/>', () => {
       fireEvent.click(getByText('Save & Next'));
 
       const selectAll = getByLabelText('All Changes');
+      expect(selectAll).toHaveFocus();
       fireEvent.click(selectAll);
       // Click forward to the commit-message modal:
       fireEvent.click(getByText('Save & Next'));
@@ -124,7 +125,7 @@ describe('<RetrieveMetadataModal/>', () => {
       fireEvent.change(commitInput, { target: { value: 'My Commit' } });
       fireEvent.click(submit);
 
-      expect.assertions(2);
+      expect.assertions(3);
       await findByText('Retrieving Selected Changes…');
 
       expect(createObject).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
[W-11151599](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000xB0kaYAC/view)

Focus order changed from the footer Go back button to the modal content.