### PR TITLE
Validate websocket origin

### DIFF
--- a/metecho/routing.py
+++ b/metecho/routing.py
@@ -1,5 +1,6 @@
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
 from django.urls import path
 
@@ -17,5 +18,8 @@ websockets = URLRouter(
 
 
 application = ProtocolTypeRouter(
-    {"http": get_asgi_application(), "websocket": AuthMiddlewareStack(websockets)}
+    {
+        "http": get_asgi_application(),
+        "websocket": AllowedHostsOriginValidator(AuthMiddlewareStack(websockets)),
+    }
 )


### PR DESCRIPTION
WebSockets can be initiated from any site on the internet and still have
the user’s cookies and session. This pull request restricts the sites
which are allowed to open sockets to the app.

See W-14666443